### PR TITLE
fix: guard gtag event calls

### DIFF
--- a/compostaje-kids-gpt.php
+++ b/compostaje-kids-gpt.php
@@ -45,7 +45,7 @@ add_action('wp_enqueue_scripts', function(){
 // Ensure a gtag() stub exists early so events can queue before the GA script loads.
 add_action('wp_head', function(){
     if (!ck_gpt_has_shortcode_page()) return;
-    echo "<script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}</script>";
+    echo "<script>window.dataLayer=window.dataLayer||[];window.gtag=window.gtag||function(){window.dataLayer.push(arguments);};</script>";
 }, 0);
 
 /* =========================
@@ -267,7 +267,9 @@ add_shortcode('compostaje_gpt', function() {
     root.innerHTML = `<style>${css}${prefersDark ? darkCSS : ''}</style>${html}`;
   }
 
-  window.gtag('event','ck_chat_loaded',{event_category:'chatbot'});
+  if (typeof window.gtag === 'function') {
+    window.gtag('event', 'ck_chat_loaded', { event_category: 'chatbot' });
+  }
 
   // JS logic isolated
   const msgsEl = root.getElementById('msgs');
@@ -340,7 +342,9 @@ add_shortcode('compostaje_gpt', function() {
   async function send(txt){
     if(!txt || sending) return;
     setSending(true);
-    window.gtag('event','ck_chat_message',{event_category:'chatbot'});
+    if (typeof window.gtag === 'function') {
+      window.gtag('event', 'ck_chat_message', { event_category: 'chatbot' });
+    }
     history.push({role:'user',content:txt});
     render('user', txt);
     fieldEl.value='';
@@ -357,14 +361,18 @@ add_shortcode('compostaje_gpt', function() {
       const reply = (data && data.reply) ? data.reply : (data && data.error ? data.error : 'No se pudo obtener respuesta.');
       history.push({role:'assistant',content:reply});
       render('ai', reply);
-      window.gtag('event','ck_chat_reply',{event_category:'chatbot'});
+      if (typeof window.gtag === 'function') {
+        window.gtag('event', 'ck_chat_reply', { event_category: 'chatbot' });
+      }
     }catch(err){
       typingOff();
       const msg = 'Ups, parece que las lombrices están dormidas. ¡Inténtalo otra vez!';
       history.push({role:'assistant',content:msg});
       render('ai', msg);
       console.error(err);
-      window.gtag('event','ck_chat_error',{event_category:'chatbot'});
+      if (typeof window.gtag === 'function') {
+        window.gtag('event', 'ck_chat_error', { event_category: 'chatbot' });
+      }
     }finally{
       persist(); scroll(); setSending(false);
     }


### PR DESCRIPTION
## Summary
- avoid "window.gtag is not a function" errors by wrapping GA event calls with a function check
- ensure the gtag stub defines `window.gtag`

## Testing
- `php -l compostaje-kids-gpt.php`


------
https://chatgpt.com/codex/tasks/task_e_68aecdb701288325a91fa8079911e856