### PR TITLE
Refocus kids compost bot on voice animation

### DIFF
--- a/compostaje-kids-gpt.php
+++ b/compostaje-kids-gpt.php
@@ -187,56 +187,49 @@ add_shortcode('compostaje_gpt', function() {
   .header .text{ flex:1; }
   .title{ margin:4px 0 2px; font-size: clamp(26px,5vw,40px); font-weight:800; }
   .desc{ margin:0; font-size: clamp(18px,3vw,26px); color:#4b5563; }
-  .chips{ display:flex; gap:12px; flex-wrap:wrap; justify-content:center; padding:12px; background:var(--mut2); border-bottom:1px solid #eef2f7; overflow-x:auto; scroll-snap-type:x mandatory; }
-  .chip{ scroll-snap-align:start; padding:10px 16px; border-radius:999px; border:1px solid var(--chip-b); background:var(--chip); cursor:pointer; font-size:clamp(18px,2.8vw,24px); color:var(--chip-text); white-space:nowrap; box-shadow:0 2px 0 rgba(0,0,0,.02); transition: background .15s,border-color .15s,transform .08s }
-  .chip:hover{ background:#eef2ff; border-color:#c7d2fe; }
-  .chip:active{ transform: translateY(1px); }
-  .chip[disabled]{ opacity:.5; cursor:not-allowed; }
-  .msgs{ flex:1; overflow-y:auto; padding:20px 24px; background:#fff; }
-  .row{ display:flex; margin:6px 0; }
-  .row.user{ justify-content:flex-end; }
-  .bubble{ max-width:90%; padding:16px 18px; border-radius:20px; line-height:1.6; white-space:pre-wrap; word-wrap:break-word; font-size:clamp(18px,2.5vw,24px); }
-  .row.user .bubble{ background:var(--us); border:1px solid var(--us-b); }
-  .row.ai .bubble{ background:var(--ai); border:1px solid var(--ai-b); }
-  .input{ display:flex; gap:12px; padding:16px 20px; border-top:1px solid var(--bd); background:#ffffff; position:sticky; bottom:0; left:0; right:0; }
-  .field{ flex:1; padding:16px 20px; border:1px solid #d1d5db; border-radius:16px; font-size:20px; outline:none; background:#fff; color:#0f172a; }
-  .field::placeholder{ color:#9aa3ae; }
-  .field:focus{ border-color:#93c5fd; box-shadow:0 0 0 3px rgba(59,130,246,.15); }
-  .send{ width:56px; min-width:56px; height:56px; display:flex; align-items:center; justify-content:center; border:none; border-radius:16px;
-         background:var(--pri); color:#fff; cursor:pointer; box-shadow: 0 1px 0 rgba(0,0,0,.12), inset 0 0 0 1px rgba(255,255,255,.2); }
-  .send:hover{ filter: brightness(1.08); }
-  .send[disabled]{ opacity:.6; cursor:not-allowed; }
-  .send svg{ width:28px; height:28px; display:block; fill:currentColor; filter: drop-shadow(0 1px 0 rgba(0,0,0,.45)); } /* visible siempre */
-    .send svg path{ stroke: rgba(0,0,0,.55); stroke-width: .6px; }
-    .mic{ width:56px; min-width:56px; height:56px; display:flex; align-items:center; justify-content:center; border:none; border-radius:16px; background:#34d399; color:#fff; cursor:pointer; box-shadow: 0 1px 0 rgba(0,0,0,.12), inset 0 0 0 1px rgba(255,255,255,.2); }
-    .mic:hover{ filter: brightness(1.08); }
-    .mic.active{ background:#dc2626; }
-    .mic svg{ width:28px; height:28px; display:block; fill:currentColor; filter: drop-shadow(0 1px 0 rgba(0,0,0,.45)); }
-    .mic[disabled]{ opacity:.6; cursor:not-allowed; }
-    .typing{ display:inline-flex; align-items:center; gap:4px; }
-  .dot{ width:6px; height:6px; border-radius:50%; background:#606770; opacity:.4; animation:blink 1.2s infinite; }
-  .dot:nth-child(2){ animation-delay:.2s; } .dot:nth-child(3){ animation-delay:.4s; }
-  @keyframes blink{ 0%,80%,100%{opacity:.2} 40%{opacity:1} }
+  .bot-stage{ position:relative; flex:1; min-height:0; border-top:1px solid #f3d1dc; background:linear-gradient(180deg,#ffeef6 0%,#fff9d7 100%); display:flex; align-items:center; justify-content:center; padding:16px 22px 24px; }
+  .bot-stage::before{ content:''; position:absolute; inset:18px 22px 90px; background:rgba(255,255,255,0.72); border-radius:32px; box-shadow:0 12px 24px rgba(255,107,107,0.25); z-index:0; transition:transform .6s ease, box-shadow .6s ease, background .4s ease; }
+  .bot-stage.is-speaking::before{ transform:scale(1.02); box-shadow:0 20px 38px rgba(255,107,107,0.45); }
+  .bot-stage.is-saying::before{ box-shadow:0 18px 34px rgba(255,211,59,0.45); }
+  .bot-stage.is-listening::before{ background:rgba(255,255,255,0.9); box-shadow:0 18px 32px rgba(59,130,246,0.35); }
+  .bot-stage.is-processing::before{ background:rgba(255,255,255,0.85); box-shadow:0 18px 32px rgba(16,185,129,0.35); }
+  canvas.bot-canvas{ position:relative; z-index:1; width:100%; height:100%; display:block; }
+  .bot-subtitle{ position:absolute; left:50%; bottom:24px; transform:translate(-50%,40px); background:#fffbe8; border:2px solid #ffd166; border-radius:18px; padding:10px 16px; font-size:clamp(16px,2.5vw,20px); color:#ff6b6b; font-weight:600; box-shadow:0 6px 16px rgba(0,0,0,0.12); max-width:80%; text-align:center; opacity:0; pointer-events:none; z-index:2; transition:opacity .35s ease, transform .35s ease; }
+  .bot-subtitle.show{ opacity:1; transform:translate(-50%,0); }
+  .voice-btn{ position:absolute; left:50%; bottom:26px; transform:translate(-50%,0); z-index:3; padding:14px 28px; border-radius:999px; border:none; font-size:clamp(18px,3vw,26px); font-weight:700; background:#ff6b6b; color:#fff; box-shadow:0 10px 22px rgba(255,107,107,0.35); cursor:pointer; transition:transform .18s ease, box-shadow .18s ease, filter .2s ease; }
+  .voice-btn:hover{ filter:brightness(1.08); }
+  .voice-btn:active{ transform:translate(-50%,2px); box-shadow:0 6px 14px rgba(255,107,107,0.4); }
+  .voice-btn[disabled]{ opacity:.5; cursor:not-allowed; box-shadow:0 8px 18px rgba(148,163,184,0.35); }
+  .bot-stage.is-listening .voice-btn{ background:#60a5fa; box-shadow:0 12px 24px rgba(96,165,250,0.45); }
+  .bot-stage.is-processing .voice-btn{ background:#34d399; box-shadow:0 12px 24px rgba(52,211,153,0.45); }
   @media (max-width:560px){
-    .chips{ justify-content:flex-start; padding:10px 8px; }
+    .header{ padding:16px 14px; }
+    .bot-stage{ padding:12px 14px 20px; }
+    .bot-stage::before{ inset:14px 16px 82px; }
+    .bot-subtitle{ bottom:18px; }
+    .voice-btn{ padding:12px 22px; }
   }
-  .input{ padding-bottom: calc(12px + env(safe-area-inset-bottom)); }
   `;
 
   // Dark theme overrides only if themeOpt == 'dark' OR (themeOpt=='auto' && prefers dark)
   const darkCSS = `
   :host{
     color-scheme: dark;
-    --bd:#2b2f36; --mut:#101318; --mut2:#0c0f14; --ai:#141922; --ai-b:#1f2430;
-    --us:#0f2540; --us-b:#15365c; --chip:#0f1420; --chip-b:#2c3444; --chip-text:#e5e7eb;
+    --bd:#2b2f36; --mut:#101318; --mut2:#0c0f14;
     color:#e5e7eb;
   }
   .wrap{ background:#0b0f14; box-shadow:none; }
+  .header{ background:#101318; border-bottom:1px solid var(--bd); }
   .desc{ color:#b3b8c2; }
-  .field{ background:#0e131a; color:#e6edf5; border-color:#293241; }
-  .field::placeholder{ color:#8b93a1; }
-  .input{ background:#0b0f14; }
-  .send{ background:var(--pri); color:#fff; }
+  .bot-stage{ border-top:1px solid #1f2933; background:linear-gradient(180deg,#111827 0%,#1f2937 100%); }
+  .bot-stage::before{ background:rgba(17,24,39,0.82); box-shadow:0 16px 32px rgba(96,165,250,0.25); }
+  .bot-stage.is-speaking::before{ box-shadow:0 22px 40px rgba(96,165,250,0.45); }
+  .bot-stage.is-saying::before{ box-shadow:0 20px 36px rgba(253,224,71,0.4); }
+  .bot-stage.is-listening::before{ background:rgba(17,24,39,0.92); box-shadow:0 20px 34px rgba(96,165,250,0.45); }
+  .bot-stage.is-processing::before{ background:rgba(17,24,39,0.9); box-shadow:0 20px 34px rgba(45,212,191,0.45); }
+  .bot-subtitle{ background:rgba(31,41,55,0.9); border-color:#60a5fa; color:#bfdbfe; }
+  .voice-btn{ background:#60a5fa; }
+  .bot-stage.is-processing .voice-btn{ background:#34d399; }
   `;
 
   // Build base HTML
@@ -246,26 +239,13 @@ add_shortcode('compostaje_gpt', function() {
         ${logoUrl ? `<img src="${logoUrl}" alt="Agente IA Compostaje CEBAS Kids">` : ''}
         <div class="text">
           <div class="title">Agente IA Compostaje CEBAS Kids</div>
-          <p class="desc">Un rincón mágico del CEBAS-CSIC donde una Inteligencia Artificial te enseña a compostar como en un cuento.</p>
+          <p class="desc">Un rincón mágico del CEBAS-CSIC donde una Inteligencia Artificial te enseña a compostar como en un cuento.<br><strong>Toca al robot o pulsa el botón para hacerle una pregunta.</strong></p>
         </div>
       </div>
-      <div class="chips" id="chips">
-        <button class="chip" data-q="¿Qué cositas puedo echar en mi compostera mágica?">¿Qué cositas puedo echar en mi compostera mágica?</button>
-        <button class="chip" data-q="¿Por qué el compost hace feliz al huerto?">¿Por qué el compost hace feliz al huerto?</button>
-        <button class="chip" data-q="¿Cuánto tarda la poción del compost?">¿Cuánto tarda la poción del compost?</button>
-        <button class="chip" data-q="¿Qué bichitos ayudan en el compost?">¿Qué bichitos ayudan en el compost?</button>
-      </div>
-      <div class="msgs" id="msgs"></div>
-      <div class="input">
-        <input class="field" id="field" type="text" placeholder="Escribe aquí tu pregunta compostera..." autocomplete="off">
-        <button class="mic" id="mic" aria-label="Hablar" title="Hablar">
-          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 14a3 3 0 003-3V5a3 3 0 10-6 0v6a3 3 0 003 3zm5-3a5 5 0 01-10 0H5a7 7 0 0014 0h-2zM11 19h2v3h-2z"></path></svg>
-          <span style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden">Hablar</span>
-        </button>
-        <button class="send" id="send" aria-label="Enviar" title="Enviar">
-          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M2.5 11.1c-.9-.4-.9-1.7 0-2.1L20.6 1.8c.9-.4 1.8.5 1.4 1.4l-7.2 18.1c-.3.8-1.5.7-1.8-.1l-2.2-5.4c-.1-.3-.4-.5-.7-.6l-7.6-3.1zM9.2 12.5l3.3 8.1 6.1-15.5-9.4 3.8 3.6 1.5c.5.2.6.9.2 1.2l-3.8 2.9z"></path></svg>
-          <span style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden">Enviar</span>
-        </button>
+      <div class="bot-stage" id="botStage" role="region" aria-live="polite">
+        <canvas class="bot-canvas" id="botCanvas"></canvas>
+        <div class="bot-subtitle" id="botSubtitle"></div>
+        <button class="voice-btn" id="voiceBtn" type="button">¡Pregúntame!</button>
       </div>
     </div>
   `;
@@ -284,142 +264,511 @@ add_shortcode('compostaje_gpt', function() {
   }
 
   // JS logic isolated
-  const msgsEl = root.getElementById('msgs');
-  const fieldEl = root.getElementById('field');
-    const sendBtn = root.getElementById('send');
-    const micBtn  = root.getElementById('mic');
-    const chips   = root.getElementById('chips');
-    let sending = false;
-    let recognition = null;
-    let selectedVoice = null;
+  const stageEl = root.getElementById('botStage');
+  const canvas = root.getElementById('botCanvas');
+  const subtitleEl = root.getElementById('botSubtitle');
+  const voiceBtn = root.getElementById('voiceBtn');
+  let sending = false;
+  let listening = false;
+  let recognition = null;
+  let selectedVoice = null;
+  let robotSpeaking = false;
+  let subtitleTimer = 0;
+  let fallbackSpeechTimeout = null;
+  let fallbackSubtitleTimeout = null;
 
-    if ('speechSynthesis' in window){
-      const pickVoice = () => {
-        const voices = window.speechSynthesis.getVoices();
-        const prefer = [
-          'Google español de España',
-          'Google español',
-          'Microsoft Helena Desktop - Spanish (Spain)'
-        ];
-        selectedVoice = voices.find(v => prefer.includes(v.name)) ||
-                        voices.find(v => v.name && v.name.toLowerCase().includes('google') && v.lang === 'es-ES') ||
-                        voices.find(v => v.lang === 'es-ES') ||
-                        voices.find(v => v.lang && v.lang.startsWith('es')) || null;
-      };
-      pickVoice();
-      window.speechSynthesis.onvoiceschanged = pickVoice;
+  const ctx = canvas && canvas.getContext ? canvas.getContext('2d') : null;
+  const stageSize = { width: 0, height: 0 };
+  const crumbs = ctx ? Array.from({length:7}, () => ({ angle: Math.random()*Math.PI*2, radius: 0.28 + Math.random()*0.35, size: 6 + Math.random()*5, color: Math.random() > 0.5 ? '#8ed16f' : '#b47b36' })) : [];
+  const sparks = ctx ? Array.from({length:6}, () => ({ angle: Math.random()*Math.PI*2, distance: 0.65 + Math.random()*0.2, speed: 0.005 + Math.random()*0.01, size: 6 + Math.random()*3, color: Math.random() > 0.5 ? '#ffadad' : '#9bf6ff' })) : [];
+  let blinkTimer = 150;
+  let blinkTarget = 0;
+  let blinkValue = 0;
+  let mouthValue = 0.2;
+  let floatPhase = 0;
+
+  function updateVoiceButtonState(){
+    if (!voiceBtn) return;
+    if (!recognition){
+      voiceBtn.disabled = true;
+      voiceBtn.textContent = 'Micrófono no disponible';
+      return;
     }
-
-  // History
-  let history = [];
-  try { const saved = localStorage.getItem('ckMessages'); if(saved) history = JSON.parse(saved); } catch(e){}
-  if (history.length) { history.forEach(m => render(m.role, m.content)); scroll(); }
-  else {
-    typingOn();
-    setTimeout(function(){
-      typingOff();
-      const welcome = '¡Hola, peque aventurerx del compost! Soy tu amigue del CEBAS-CSIC. Juntxs haremos magia con las cáscaras y las hojas para alimentar a las plantas. ¿Qué te gustaría saber?';
-      history.push({role:'assistant',content:welcome});
-      render('ai', welcome, false);
-      persist();
-      scroll();
-    },2000);
+    if (listening){
+      voiceBtn.disabled = true;
+      voiceBtn.textContent = '¡Te escucho!';
+    } else if (sending){
+      voiceBtn.disabled = true;
+      voiceBtn.textContent = 'Pensando...';
+    } else {
+      voiceBtn.disabled = false;
+      voiceBtn.textContent = '¡Pregúntame!';
+    }
   }
 
-  function persist(){ try{ localStorage.setItem('ckMessages', JSON.stringify(history)); } catch(e){} }
-    function scroll(){ msgsEl.scrollTop = msgsEl.scrollHeight; }
-    function setSending(state){ sending = state; sendBtn.disabled = state; Array.from(chips.children).forEach(b=>b.disabled=state); }
-    function typingOn(){ render('ai','',true); scroll(); }
-    function typingOff(){ Array.from(msgsEl.querySelectorAll('[data-typing="1"]')).forEach(n=>n.remove()); }
+  function updateStageStateFallback(){
+    if (ctx) return;
+    const hasSubtitle = subtitleEl && subtitleEl.textContent.trim().length > 0;
+    const showSubtitle = (robotSpeaking || subtitleTimer > 0) && hasSubtitle;
+    stageEl.classList.toggle('is-speaking', robotSpeaking);
+    stageEl.classList.toggle('is-saying', showSubtitle);
+    if (subtitleEl){
+      subtitleEl.classList.toggle('show', showSubtitle);
+    }
+  }
 
+  function scheduleFallbackHide(ms){
+    if (ctx) return;
+    clearTimeout(fallbackSubtitleTimeout);
+    fallbackSubtitleTimeout = setTimeout(()=>{
+      subtitleTimer = 0;
+      robotSpeaking = false;
+      if (subtitleEl) subtitleEl.textContent = '';
+      updateStageStateFallback();
+    }, ms);
+  }
 
-    function typeText(el, text){
-      let i = 0;
-      const speed = 27;
-      (function add(){
-        el.textContent += text.charAt(i);
-        i++; scroll();
-        if(i < text.length){ setTimeout(add, speed); }
-      })();
+  function robotShowSubtitle(text){
+    if (!subtitleEl) return;
+    if (!text){
+      subtitleTimer = 0;
+      subtitleEl.textContent = '';
+      subtitleEl.classList.remove('show');
+      stageEl.classList.remove('is-saying');
+      updateStageStateFallback();
+      return;
+    }
+    subtitleEl.textContent = text;
+    subtitleTimer = 260;
+    updateStageStateFallback();
+    scheduleFallbackHide(3200);
+  }
+
+  function robotStartSpeaking(){
+    clearTimeout(fallbackSpeechTimeout);
+    if (!ctx) clearTimeout(fallbackSubtitleTimeout);
+    robotSpeaking = true;
+    subtitleTimer = Math.max(subtitleTimer, 260);
+    stageEl.classList.remove('is-processing');
+    updateStageStateFallback();
+  }
+
+  function robotStopSpeaking(){
+    clearTimeout(fallbackSpeechTimeout);
+    if (robotSpeaking) subtitleTimer = Math.max(subtitleTimer, 120);
+    robotSpeaking = false;
+    floatPhase = 0;
+    blinkTarget = 0;
+    blinkTimer = 150;
+    updateStageStateFallback();
+    scheduleFallbackHide(2000);
+  }
+
+  function robotSimulateSpeech(duration){
+    robotStartSpeaking();
+    fallbackSpeechTimeout = setTimeout(()=>{ robotStopSpeaking(); }, duration);
+  }
+
+  if (ctx){
+    const drawRoundedRect = (x,y,w,h,r)=>{
+      const rr = Math.min(r, h/2, w/2);
+      ctx.beginPath();
+      ctx.moveTo(x+rr, y);
+      ctx.lineTo(x+w-rr, y);
+      ctx.quadraticCurveTo(x+w, y, x+w, y+rr);
+      ctx.lineTo(x+w, y+h-rr);
+      ctx.quadraticCurveTo(x+w, y+h, x+w-rr, y+h);
+      ctx.lineTo(x+rr, y+h);
+      ctx.quadraticCurveTo(x, y+h, x, y+h-rr);
+      ctx.lineTo(x, y+rr);
+      ctx.quadraticCurveTo(x, y, x+rr, y);
+      ctx.closePath();
+    };
+
+    function resizeRobot(){
+      const rect = stageEl.getBoundingClientRect();
+      const dpr = window.devicePixelRatio || 1;
+      canvas.width = rect.width * dpr;
+      canvas.height = rect.height * dpr;
+      canvas.style.width = rect.width + 'px';
+      canvas.style.height = rect.height + 'px';
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      stageSize.width = rect.width;
+      stageSize.height = rect.height;
     }
 
-    function speakAndType(el, text){
-      if (!('speechSynthesis' in window)) { typeText(el, text); return; }
-      const clean = text
-        .replace(/[\u{1F300}-\u{1FAFF}]/gu, '')
-        .replace(/[\*#_~`>\[\]\(\){}]/g, '')
-        .replace(/<[^>]*>/g, '');
-      const u = new SpeechSynthesisUtterance(clean);
-      u.lang = 'es-ES';
-      u.pitch = 1.1;
-      u.rate  = 1;
-      if (selectedVoice) u.voice = selectedVoice;
-      window.speechSynthesis.cancel();
-      window.speechSynthesis.speak(u);
-      typeText(el, text);
+    resizeRobot();
+    window.addEventListener('resize', resizeRobot);
+    if (window.ResizeObserver){
+      try {
+        const ro = new ResizeObserver(resizeRobot);
+        ro.observe(stageEl);
+      } catch(e){}
     }
 
+    function drawCloud(x,y,scale){
+      ctx.save();
+      ctx.translate(x, y);
+      ctx.scale(scale, scale);
+      ctx.fillStyle = 'rgba(255,255,255,0.85)';
+      ctx.beginPath();
+      ctx.arc(-20, 0, 22, 0, Math.PI*2);
+      ctx.arc(10, -8, 26, 0, Math.PI*2);
+      ctx.arc(36, 6, 20, 0, Math.PI*2);
+      ctx.arc(0, 12, 24, 0, Math.PI*2);
+      ctx.fill();
+      ctx.restore();
+    }
 
-    function render(role, text, typing=false){
-      const row = document.createElement('div');
-      row.className = 'row ' + (role==='user'?'user':'ai');
-      const bubble = document.createElement('div');
-      bubble.className = 'bubble';
-      if (typing){
-        row.dataset.typing = '1';
-        const t = document.createElement('div');
-        t.className = 'typing';
-        t.innerHTML = '<span class="dot"></span><span class="dot"></span><span class="dot"></span>';
-        bubble.appendChild(t);
-      } else {
-        const txt = document.createElement('div');
-        bubble.appendChild(txt);
-          if(role === 'ai'){
-            speakAndType(txt, text);
-          } else {
-            txt.textContent = text;
-          }
+    function loop(){
+      if (!stageSize.width || !stageSize.height){
+        requestAnimationFrame(loop);
+        return;
       }
-      row.appendChild(bubble);
-      msgsEl.appendChild(row);
+
+      if (robotSpeaking){
+        floatPhase += 1;
+        blinkTimer--;
+        if (blinkTimer <= 0){
+          blinkTarget = 1;
+          blinkTimer = 160 + Math.random()*120;
+        }
+        blinkValue += (blinkTarget - blinkValue) * 0.2;
+        if (blinkTarget === 1 && blinkValue > 0.9){
+          blinkTarget = 0;
+        }
+      } else {
+        blinkTarget = 0;
+        blinkValue += (0 - blinkValue) * 0.25;
+      }
+
+      const effectivePhase = robotSpeaking ? floatPhase : 0;
+      const mouthTarget = robotSpeaking ? 0.72 + 0.18*Math.sin(effectivePhase*0.25) : 0.2;
+      mouthValue += (mouthTarget - mouthValue) * (robotSpeaking ? 0.25 : 0.18);
+
+      if (robotSpeaking){
+        subtitleTimer = Math.max(subtitleTimer, 200);
+      } else if (subtitleTimer > 0){
+        subtitleTimer = Math.max(0, subtitleTimer - 1);
+      }
+
+      const hasSubtitle = subtitleEl && subtitleEl.textContent.trim().length > 0;
+      const showSubtitle = (robotSpeaking || subtitleTimer > 0) && hasSubtitle;
+      stageEl.classList.toggle('is-speaking', robotSpeaking);
+      stageEl.classList.toggle('is-saying', showSubtitle);
+      if (subtitleEl){
+        subtitleEl.classList.toggle('show', showSubtitle);
+      }
+
+      const w = stageSize.width;
+      const h = stageSize.height;
+      ctx.clearRect(0,0,w,h);
+
+      const sunX = w*0.12;
+      const sunY = h*0.18;
+      ctx.fillStyle = '#ffe066';
+      ctx.beginPath();
+      ctx.arc(sunX, sunY, 26, 0, Math.PI*2);
+      ctx.fill();
+      ctx.strokeStyle = 'rgba(255,209,102,0.7)';
+      ctx.lineWidth = 3;
+      for (let i=0;i<10;i++){
+        const angle = (Math.PI*2/10)*i + effectivePhase*0.02;
+        ctx.beginPath();
+        ctx.moveTo(sunX + Math.cos(angle)*30, sunY + Math.sin(angle)*30);
+        ctx.lineTo(sunX + Math.cos(angle)*44, sunY + Math.sin(angle)*44);
+        ctx.stroke();
+      }
+
+      drawCloud(w*0.72, h*0.18 + Math.sin(effectivePhase*0.01)*(robotSpeaking ? 6 : 0), 0.9);
+      drawCloud(w*0.45, h*0.12 + Math.cos(effectivePhase*0.012)*(robotSpeaking ? 4 : 0), 0.7);
+
+      const groundY = h*0.78 + (robotSpeaking ? Math.sin(effectivePhase*0.02)*3 : 0);
+      ctx.fillStyle = '#b8f5a3';
+      ctx.beginPath();
+      ctx.moveTo(0, groundY);
+      ctx.quadraticCurveTo(w*0.25, groundY-24, w*0.5, groundY-10);
+      ctx.quadraticCurveTo(w*0.8, groundY+8, w, groundY-18);
+      ctx.lineTo(w, h);
+      ctx.lineTo(0, h);
+      ctx.closePath();
+      ctx.fill();
+
+      ctx.fillStyle = '#7bd7f0';
+      ctx.beginPath();
+      ctx.moveTo(0, groundY);
+      ctx.bezierCurveTo(w*0.2, groundY-18, w*0.35, groundY-6, w*0.5, groundY-12);
+      ctx.bezierCurveTo(w*0.7, groundY-24, w*0.85, groundY-6, w, groundY-20);
+      ctx.lineTo(w, groundY);
+      ctx.closePath();
+      ctx.fill();
+
+      const bob = robotSpeaking ? Math.sin(effectivePhase*0.05) * 10 : 0;
+      const centerX = w/2;
+      const baseY = groundY - 16 + bob;
+      const bodyW = Math.min(220, w*0.55);
+      const bodyH = Math.min(170, h*0.5);
+      const bodyX = centerX - bodyW/2;
+      const bodyY = baseY - bodyH;
+
+      ctx.fillStyle = 'rgba(0,0,0,0.08)';
+      ctx.beginPath();
+      ctx.ellipse(centerX, baseY+8, bodyW*0.45, 18, 0, 0, Math.PI*2);
+      ctx.fill();
+
+      ctx.strokeStyle = '#2f8f67';
+      ctx.lineCap = 'round';
+      ctx.lineWidth = 12;
+      ctx.beginPath();
+      ctx.moveTo(centerX - bodyW*0.22, baseY-6);
+      ctx.lineTo(centerX - bodyW*0.22, baseY+10);
+      ctx.moveTo(centerX + bodyW*0.22, baseY-6);
+      ctx.lineTo(centerX + bodyW*0.22, baseY+10);
+      ctx.stroke();
+
+      ctx.fillStyle = '#57cc99';
+      ctx.strokeStyle = '#2f8f67';
+      ctx.lineWidth = 6;
+      drawRoundedRect(bodyX, bodyY, bodyW, bodyH, 32);
+      ctx.fill();
+      ctx.stroke();
+
+      const lidH = bodyH*0.18;
+      const lidY = bodyY - lidH*0.45;
+      ctx.fillStyle = '#38a3a5';
+      drawRoundedRect(bodyX + bodyW*0.08, lidY, bodyW*0.84, lidH, 20);
+      ctx.fill();
+
+      ctx.strokeStyle = '#2f8f67';
+      ctx.lineWidth = 5;
+      ctx.beginPath();
+      ctx.moveTo(centerX, lidY);
+      ctx.quadraticCurveTo(centerX, lidY-30 - Math.sin(effectivePhase*0.09)*(robotSpeaking?6:0), centerX, lidY-48 - Math.sin(effectivePhase*0.09)*(robotSpeaking?6:0));
+      ctx.stroke();
+      ctx.fillStyle = '#ffd166';
+      ctx.beginPath();
+      ctx.arc(centerX, lidY-56 - Math.sin(effectivePhase*0.09)*(robotSpeaking?6:0), 10, 0, Math.PI*2);
+      ctx.fill();
+
+      const faceH = bodyH*0.42;
+      const faceY = bodyY + bodyH*0.12;
+      const faceX = bodyX + bodyW*0.1;
+      const faceW = bodyW*0.8;
+      ctx.fillStyle = '#9bf6ff';
+      drawRoundedRect(faceX, faceY, faceW, faceH, 24);
+      ctx.fill();
+
+      ctx.fillStyle = '#ffcad4';
+      ctx.beginPath();
+      ctx.ellipse(faceX + faceW*0.18, faceY + faceH*0.65, 16, 12, 0, 0, Math.PI*2);
+      ctx.ellipse(faceX + faceW*0.82, faceY + faceH*0.65, 16, 12, 0, 0, Math.PI*2);
+      ctx.fill();
+
+      const eyeOpen = Math.max(0.1, 1 - blinkValue);
+      const eyeW = 24;
+      const eyeH = 18 * eyeOpen;
+      const eyeY = faceY + faceH*0.42;
+      const eyeOffset = faceW*0.26;
+      ctx.fillStyle = '#ffffff';
+      ctx.beginPath();
+      ctx.ellipse(centerX - eyeOffset, eyeY, eyeW, Math.max(6, eyeH), 0, 0, Math.PI*2);
+      ctx.ellipse(centerX + eyeOffset, eyeY, eyeW, Math.max(6, eyeH), 0, 0, Math.PI*2);
+      ctx.fill();
+
+      ctx.fillStyle = '#1f3b4d';
+      const pupilBob = robotSpeaking ? Math.sin(effectivePhase*0.05)*3 : 0;
+      ctx.beginPath();
+      ctx.ellipse(centerX - eyeOffset, eyeY + pupilBob, 10, Math.max(4, eyeH*0.4), 0, 0, Math.PI*2);
+      ctx.ellipse(centerX + eyeOffset, eyeY + pupilBob, 10, Math.max(4, eyeH*0.4), 0, 0, Math.PI*2);
+      ctx.fill();
+
+      const mouthW = faceW*0.42;
+      const mouthH = 10 + 28*mouthValue;
+      const mouthY = faceY + faceH*0.72;
+      ctx.fillStyle = '#ff9f1c';
+      drawRoundedRect(centerX - mouthW/2, mouthY - mouthH/2, mouthW, mouthH, 14);
+      ctx.fill();
+      ctx.fillStyle = '#1f3b4d';
+      ctx.fillRect(centerX - mouthW*0.35, mouthY - 3, mouthW*0.7, 6);
+
+      const armY = faceY + faceH*0.78;
+      const wave = robotSpeaking ? Math.sin(effectivePhase*0.08) * 22 : 0;
+      ctx.strokeStyle = '#38a3a5';
+      ctx.lineCap = 'round';
+      ctx.lineWidth = 12;
+      ctx.beginPath();
+      ctx.moveTo(bodyX + 12, armY);
+      ctx.quadraticCurveTo(bodyX - bodyW*0.25, armY - wave - 10, bodyX - bodyW*0.18, armY + wave);
+      ctx.stroke();
+      ctx.beginPath();
+      ctx.moveTo(bodyX + bodyW - 12, armY);
+      ctx.quadraticCurveTo(bodyX + bodyW + bodyW*0.25, armY - wave - 10, bodyX + bodyW + bodyW*0.18, armY + wave);
+      ctx.stroke();
+
+      ctx.fillStyle = '#ff6b6b';
+      ctx.beginPath();
+      ctx.ellipse(bodyX - bodyW*0.2, armY + wave, 14, 14, 0, 0, Math.PI*2);
+      ctx.ellipse(bodyX + bodyW + bodyW*0.2, armY + wave, 14, 14, 0, 0, Math.PI*2);
+      ctx.fill();
+
+      const windowR = bodyW*0.32;
+      const windowY = bodyY + bodyH*0.7;
+      ctx.fillStyle = '#1f3b4d';
+      ctx.beginPath();
+      ctx.ellipse(centerX, windowY, windowR, windowR*0.65, 0, 0, Math.PI*2);
+      ctx.fill();
+      ctx.fillStyle = '#b2f2bb';
+      ctx.beginPath();
+      ctx.ellipse(centerX, windowY, windowR-8, windowR*0.65-8, 0, 0, Math.PI*2);
+      ctx.fill();
+
+      ctx.save();
+      ctx.beginPath();
+      ctx.ellipse(centerX, windowY, windowR-8, windowR*0.65-8, 0, 0, Math.PI*2);
+      ctx.clip();
+      if (robotSpeaking){
+        crumbs.forEach((crumb)=>{
+          crumb.angle += 0.01 + crumb.radius*0.02;
+        });
+        sparks.forEach((spark)=>{
+          spark.angle += spark.speed * 1.5;
+        });
+      }
+      crumbs.forEach((crumb)=>{
+        const cx = centerX + Math.cos(crumb.angle) * (windowR-22) * crumb.radius;
+        const cy = windowY + Math.sin(crumb.angle) * (windowR*0.6-18) * crumb.radius;
+        ctx.fillStyle = crumb.color;
+        ctx.beginPath();
+        ctx.ellipse(cx, cy, crumb.size*0.5, crumb.size*0.35, crumb.angle, 0, Math.PI*2);
+        ctx.fill();
+      });
+      ctx.restore();
+
+      sparks.forEach((spark, index)=>{
+        const radius = (windowR + 30) * spark.distance;
+        const sx = centerX + Math.cos(spark.angle + index) * radius;
+        const sy = windowY - 30 + Math.sin(spark.angle + index) * (radius*0.4);
+        ctx.save();
+        ctx.translate(sx, sy - Math.sin(effectivePhase*0.03 + index)*(robotSpeaking?6:0));
+        const size = spark.size + (robotSpeaking ? 3 : 0);
+        ctx.fillStyle = spark.color;
+        ctx.beginPath();
+        ctx.moveTo(0, 0);
+        ctx.bezierCurveTo(-size*0.6, -size*0.6, -size, size*0.4, 0, size);
+        ctx.bezierCurveTo(size, size*0.4, size*0.6, -size*0.6, 0, 0);
+        ctx.fill();
+        ctx.restore();
+      });
+
+      requestAnimationFrame(loop);
     }
+
+    requestAnimationFrame(loop);
+  }
+
+  if ('speechSynthesis' in window){
+    const pickVoice = () => {
+      const voices = window.speechSynthesis.getVoices();
+      const prefer = [
+        'Google español de España',
+        'Google español',
+        'Microsoft Helena Desktop - Spanish (Spain)'
+      ];
+      selectedVoice = voices.find(v => prefer.includes(v.name)) ||
+                      voices.find(v => v.name && v.name.toLowerCase().includes('google') && v.lang === 'es-ES') ||
+                      voices.find(v => v.lang === 'es-ES') ||
+                      voices.find(v => v.lang && v.lang.startsWith('es')) || null;
+    };
+    pickVoice();
+    window.speechSynthesis.onvoiceschanged = pickVoice;
+  }
+
+  const history = [];
+
+  function speakText(text){
+    const clean = (text || '').replace(/[\u{1F300}-\u{1FAFF}]/gu, '').replace(/[\*#_~`>\[\]\(\){}]/g, '').replace(/<[^>]*>/g, '');
+    const preview = clean.replace(/\s+/g, ' ').trim();
+    if (preview){
+      const shown = preview.length > 160 ? preview.slice(0,157) + '…' : preview;
+      robotShowSubtitle(shown);
+    }
+
+    if ('speechSynthesis' in window){
+      robotStopSpeaking();
+      window.speechSynthesis.cancel();
+      const utterance = new SpeechSynthesisUtterance((clean || text || '').trim());
+      utterance.lang = 'es-ES';
+      utterance.pitch = 1.1;
+      utterance.rate  = 1;
+      if (selectedVoice) utterance.voice = selectedVoice;
+      utterance.onstart = () => { robotStartSpeaking(); };
+      utterance.onend = () => { robotStopSpeaking(); };
+      utterance.oncancel = () => { robotStopSpeaking(); };
+      utterance.onpause = () => { robotStopSpeaking(); };
+      utterance.onresume = () => { robotStartSpeaking(); };
+      try {
+        window.speechSynthesis.speak(utterance);
+      } catch(e){
+        if (preview){
+          robotStopSpeaking();
+          robotSimulateSpeech(Math.min(7000, Math.max(1800, preview.length * 55)));
+        }
+      }
+    } else if (preview){
+      robotStopSpeaking();
+      robotSimulateSpeech(Math.min(7000, Math.max(1800, preview.length * 55)));
+    }
+  }
+
+  function setProcessing(state){
+    sending = state;
+    stageEl.classList.toggle('is-processing', state);
+    updateVoiceButtonState();
+  }
 
   async function send(txt){
-    if(!txt || sending) return;
-    setSending(true);
+    if (!txt || sending) return;
+    setProcessing(true);
     if (typeof window.gtag === 'function') {
       window.gtag('event', 'ck_chat_message', { event_category: 'chatbot' });
     }
     history.push({role:'user',content:txt});
-    render('user', txt);
-    fieldEl.value='';
-    typingOn();
+    robotShowSubtitle('¡Déjame pensar un momento!');
     try{
       const res = await fetch(ajaxUrl, {
         method:'POST',
         headers:{'Content-Type':'application/json'},
         credentials:'same-origin',
-        body: JSON.stringify({messages: history})
+        body: JSON.stringify({messages: history.slice(-16)})
       });
       const data = await res.json();
-      typingOff();
       const reply = (data && data.reply) ? data.reply : (data && data.error ? data.error : 'No se pudo obtener respuesta.');
       history.push({role:'assistant',content:reply});
-      render('ai', reply);
+      speakText(reply);
       if (typeof window.gtag === 'function') {
         window.gtag('event', 'ck_chat_reply', { event_category: 'chatbot' });
       }
     }catch(err){
-      typingOff();
       const msg = 'Ups, parece que las lombrices están dormidas. ¡Inténtalo otra vez!';
       history.push({role:'assistant',content:msg});
-      render('ai', msg);
+      speakText(msg);
       console.error(err);
       if (typeof window.gtag === 'function') {
         window.gtag('event', 'ck_chat_error', { event_category: 'chatbot' });
       }
     }finally{
-      persist(); scroll(); setSending(false);
+      setProcessing(false);
+    }
+  }
+
+  function startListening(){
+    if (!recognition || listening || sending) return;
+    try {
+      recognition.start();
+    } catch(err){
+      if (err && err.name === 'NotAllowedError'){
+        robotShowSubtitle('Necesito permiso para usar el micrófono.');
+      }
     }
   }
 
@@ -430,22 +779,55 @@ add_shortcode('compostaje_gpt', function() {
     recognition.interimResults = false;
     recognition.onresult = (e) => {
       const transcript = e.results[0][0].transcript.trim();
-      if (transcript) send(transcript);
+      if (transcript) {
+        robotShowSubtitle('¡Genial! Estoy preparando una respuesta...');
+        send(transcript);
+      }
     };
-    recognition.onstart = () => { micBtn.classList.add('active'); };
-    recognition.onend = () => { micBtn.classList.remove('active'); };
+    recognition.onstart = () => {
+      listening = true;
+      stageEl.classList.add('is-listening');
+      robotShowSubtitle('¡Te escucho! Habla clarito.');
+      updateVoiceButtonState();
+    };
+    recognition.onend = () => {
+      listening = false;
+      stageEl.classList.remove('is-listening');
+      updateVoiceButtonState();
+      if (!robotSpeaking) robotShowSubtitle('');
+    };
+    recognition.onerror = (e) => {
+      listening = false;
+      stageEl.classList.remove('is-listening');
+      updateVoiceButtonState();
+      if (e && e.error !== 'no-speech'){
+        robotShowSubtitle('No pude escucharlo, probemos otra vez.');
+      }
+    };
+    updateVoiceButtonState();
   } else {
-    micBtn.disabled = true;
+    updateVoiceButtonState();
+    if (subtitleEl){
+      robotShowSubtitle('Tu navegador no permite usar micrófono aquí.');
+    }
   }
 
-  sendBtn.addEventListener('click', ()=> send(fieldEl.value.trim()));
-  micBtn.addEventListener('click', ()=>{ if(recognition) recognition.start(); });
-  fieldEl.addEventListener('keydown', (e)=>{ if(e.key==='Enter' && !e.shiftKey){ e.preventDefault(); send(fieldEl.value.trim()); } });
-  chips.addEventListener('click', (e)=>{
-    const b = e.target.closest('.chip'); if(!b) return;
-    const q = b.getAttribute('data-q'); if(q) send(q);
-  });
+  if (voiceBtn){
+    voiceBtn.addEventListener('click', (e)=>{
+      e.stopPropagation();
+      startListening();
+    });
+  }
+  if (stageEl){
+    stageEl.addEventListener('click', (e)=>{
+      if (voiceBtn && voiceBtn.contains(e.target)) return;
+      startListening();
+    });
+  }
 
+  const welcome = '¡Hola, peque aventurerx del compost! Soy tu amigue del CEBAS-CSIC. Juntxs haremos magia con las cáscaras y las hojas para alimentar a las plantas. ¿Qué te gustaría saber?';
+  history.push({role:'assistant',content:welcome});
+  setTimeout(()=>{ speakText(welcome); }, 1200);
   // Ajuste de altura ya manejado con flexbox
 })();
 </script>


### PR DESCRIPTION
## Summary
- Replace the chat log and input UI with a full-screen robot stage and playful voice button so the canvas owns the entire interaction area.
- Update the drawing loop and state handling so the compost robot stays still when silent and animates only during speech, including sparkles and compost swirl adjustments.
- Rebuild interaction logic around speech synthesis and speech recognition cues, showing subtitles and status glows without rendering text bubbles.

## Testing
- php -l compostaje-kids-gpt.php

------
https://chatgpt.com/codex/tasks/task_e_68dcdf0864788325a48a32146afff14c