### PR TITLE
Fix chatbot overlay mounting without wiping the page layout

### DIFF
--- a/compostaje-kids-gpt.php
+++ b/compostaje-kids-gpt.php
@@ -131,7 +131,7 @@ add_shortcode('compostaje_gpt', function() {
      data-logo="<?php echo $logo; ?>"
      data-ajax="<?php echo $ajax; ?>"
      data-theme="<?php echo $theme ? $theme : 'light'; ?>"
-     style="display:block;contain:content;position:relative;z-index:1;"></div>
+     style="display:block;position:relative;z-index:1;"></div>
 
 <script>
 (function(){
@@ -150,11 +150,8 @@ add_shortcode('compostaje_gpt', function() {
   const themeOpt  = (mount.getAttribute('data-theme') || 'light').toLowerCase();
   const overlay = document.createElement('div');
   overlay.style.cssText = 'position:fixed;inset:0;z-index:999999;background:url(https://consultoriainformatica.net/wp-content/uploads/2025/08/Chatbot-en-el-Jardin-Compostero.jpg) center/cover no-repeat;display:flex;justify-content:center;align-items:center;';
-  document.body.innerHTML = '';
-  document.documentElement.style.height = '100%';
-  document.body.style.height = '100%';
-  document.body.style.margin = '0';
-  document.body.appendChild(overlay);
+  mount.innerHTML = '';
+  mount.appendChild(overlay);
 
   const host = document.createElement('div');
   host.style.cssText = 'position:relative;width:90vw;height:90vh;max-width:1400px;max-height:900px;';


### PR DESCRIPTION
## Summary
- stop replacing the document body when mounting the chatbot overlay and append it inside the shortcode mount element instead
- remove the mount container's `contain: content` style so the fixed overlay can cover the viewport without clipping

## Testing
- manual verification in a local browser harness confirming the overlay covers the viewport while the rest of the page markup remains intact

------
https://chatgpt.com/codex/tasks/task_e_68dcfcdc3f2c8325bce083383c89ee72